### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wulfland/dc3f49e0-ea99-4a3a-b60c-772563921d52/e625f6c9-996b-4916-8e05-542c2cde028c/_apis/work/boardbadge/b675898f-85c1-4ee1-92b9-2f484b1256a0)](https://dev.azure.com/wulfland/dc3f49e0-ea99-4a3a-b60c-772563921d52/_boards/board/t/e625f6c9-996b-4916-8e05-542c2cde028c/Microsoft.RequirementCategory)
 # AccelerateDevOps
 
 Jira Smart commits:


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#25](https://dev.azure.com/wulfland/dc3f49e0-ea99-4a3a-b60c-772563921d52/_workitems/edit/25). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.