### PR TITLE
Revert "Bump SixLabors.ImageSharp from 1.0.0-beta0006 to 1.0.4 in /ch9_release/src/Tailwind.Traders.Web"

### DIFF
--- a/ch9_release/src/Tailwind.Traders.Web/Tailwind.Traders.Web.csproj
+++ b/ch9_release/src/Tailwind.Traders.Web/Tailwind.Traders.Web.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.10.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.6" />
-	  <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+	  <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts wulfland/AccelerateDevOps#136